### PR TITLE
Specify credentials sanitation

### DIFF
--- a/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
+++ b/python_modules/libraries/dagster-managed-elements/dagster_managed_elements/types.py
@@ -10,7 +10,7 @@ class ManagedElementError(enum.Enum):
     CANNOT_CONNECT = "cannot_connect"
 
 
-SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials"]
+SANITIZE_KEY_KEYWORDS = ["password", "token", "secret", "ssh_key", "credentials_json"]
 SANITIZE_KEY_EXACT_MATCHES = ["pat"]
 
 SECRET_MASK_VALUE = "**********"


### PR DESCRIPTION
Sanitizing specifically credentials_json as only "credentials" is too broad. Data sources such as Hubspot have "credentials" as a nested key that needs to be a plaintext string. Otherwise those keys are always caught in the diff.

### Summary & Motivation

### How I Tested These Changes
